### PR TITLE
First draft of annotations for HcpSocial

### DIFF
--- a/hcp/video_annotations/hcp_social_run-01_dir-pa_video-labels.tsv
+++ b/hcp/video_annotations/hcp_social_run-01_dir-pa_video-labels.tsv
@@ -1,0 +1,11 @@
+trial_type
+mental
+random
+random
+mental
+random
+mental
+mental
+random
+mental
+random


### PR DESCRIPTION
I just marked the type of clip for the video that is available here in the repo, which corresponds to run-01.
It is quite simple, because I think the relevant timing information is contained at the event files at the subject level, and thus available when downloading the source data. 
Wha do you think @bthirion ?